### PR TITLE
Allow both version 1 and 2 of league/oauth2-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "league/oauth2-client": "~1.4"
+    "league/oauth2-client": "^1.4.0 || ^2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Also, allow version 2.x to update. Currently, 2.3 is allowed, but 2.6 (latest) is not.